### PR TITLE
Adjust macOS modifier keyboard events

### DIFF
--- a/src/platform/macos/input.cpp
+++ b/src/platform/macos/input.cpp
@@ -262,6 +262,7 @@ const KeyCodeMap kKeyCodesMap[] = {
         key == kVK_Command || key == kVK_RightCommand ||
         key == kVK_Option || key == kVK_RightOption ||
         key == kVK_Control || key == kVK_RightControl) {
+      CGEventSetIntegerValueField(event, kCGKeyboardEventKeycode, key);
       CGEventFlags mask;
 
       switch (key) {
@@ -284,7 +285,7 @@ const KeyCodeMap kKeyCodesMap[] = {
       }
 
       macos_input->kb_flags = release ? macos_input->kb_flags & ~mask : macos_input->kb_flags | mask;
-      CGEventSetType(event, kCGEventFlagsChanged);
+      CGEventSetType(event, release ? kCGEventKeyUp : kCGEventKeyDown);
       CGEventSetFlags(event, macos_input->kb_flags);
     } else {
       CGEventSetIntegerValueField(event, kCGKeyboardEventKeycode, key);


### PR DESCRIPTION
## Summary
- ensure macOS keyboard modifier events write the keycode field before posting
- emit key-down/up events for modifier keys while keeping the existing flag tracking logic

## Testing
- not run (requires macOS environment for verification)


------
https://chatgpt.com/codex/tasks/task_e_68c9194d99a08321831a8dc3accb92b7