### PR TITLE
Release macOS audio capture session during teardown

### DIFF
--- a/src/platform/macos/av_audio.m
+++ b/src/platform/macos/av_audio.m
@@ -55,10 +55,14 @@
 
 - (void)dealloc {
   // make sure we don't process any further samples
+  [self.audioCaptureSession stopRunning];
+  [self.audioCaptureSession release];
+  self.audioCaptureSession = nil;
   self.audioConnection = nil;
   // make sure nothing gets stuck on this signal
   [self.samplesArrivedSignal signal];
   [self.samplesArrivedSignal release];
+  self.samplesArrivedSignal = nil;
   TPCircularBufferCleanup(&audioSampleBuffer);
   [super dealloc];
 }


### PR DESCRIPTION
## Summary
- stop and release the AVCaptureSession when `AVAudio` is deallocated
- clear the condition signal reference after releasing it to avoid dangling pointers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c99c4f64e88321901ad82f16f78712