### PR TITLE
Release macOS capture session after detaching outputs

### DIFF
--- a/src/platform/macos/av_video.m
+++ b/src/platform/macos/av_video.m
@@ -74,10 +74,35 @@
 }
 
 - (void)dealloc {
-  [self.videoOutputs release];
-  [self.captureCallbacks release];
-  [self.captureSignals release];
   [self.session stopRunning];
+
+  NSArray *outputs = [[self.session outputs] copy];
+  for (AVCaptureOutput *output in outputs) {
+    if ([output isKindOfClass:[AVCaptureVideoDataOutput class]]) {
+      [(AVCaptureVideoDataOutput *) output setSampleBufferDelegate:nil queue:NULL];
+    }
+    [self.session removeOutput:output];
+  }
+  [outputs release];
+
+  NSArray *inputs = [[self.session inputs] copy];
+  for (AVCaptureInput *input in inputs) {
+    [self.session removeInput:input];
+  }
+  [inputs release];
+
+  [self.videoOutputs release];
+  self.videoOutputs = nil;
+
+  [self.captureCallbacks release];
+  self.captureCallbacks = nil;
+
+  [self.captureSignals release];
+  self.captureSignals = nil;
+
+  [self.session release];
+  self.session = nil;
+
   [super dealloc];
 }
 


### PR DESCRIPTION
## Summary
- stop the macOS capture session before tearing it down
- detach inputs/outputs and clear delegates prior to releasing the session and maps

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c99c4ff210832190e7572f68ca7a90