### PR TITLE
Release screen input after adding to session

### DIFF
--- a/src/platform/macos/av_video.m
+++ b/src/platform/macos/av_video.m
@@ -63,6 +63,7 @@
 
   if ([self.session canAddInput:screenInput]) {
     [self.session addInput:screenInput];
+    [screenInput release];
   } else {
     [screenInput release];
     return nil;


### PR DESCRIPTION
## Summary
- release the screen capture input after successfully adding it to the capture session to avoid leaking the input

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c9984aa66083219b79987660d873e8