### PR TITLE
Release capture queue and output after registration

### DIFF
--- a/src/platform/macos/av_video.m
+++ b/src/platform/macos/av_video.m
@@ -107,6 +107,7 @@
       [self.session addOutput:videoOutput];
     } else {
       [videoOutput release];
+      dispatch_release(recordingQueue);
       return nil;
     }
 
@@ -114,6 +115,8 @@
     dispatch_semaphore_t signal = dispatch_semaphore_create(0);
 
     [self.videoOutputs setObject:videoOutput forKey:videoConnection];
+    dispatch_release(recordingQueue);
+    [videoOutput release];
     [self.captureCallbacks setObject:frameCallback forKey:videoConnection];
     [self.captureSignals setObject:signal forKey:videoConnection];
 


### PR DESCRIPTION
## Summary
- release the capture queue if the video output cannot be added to the session
- release the capture queue and video output after the output is stored

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c9984bb66c8321b28e0f3aa0ffd50a