### PR TITLE
Fix macOS audio capture memory management

### DIFF
--- a/src/platform/macos/av_audio.m
+++ b/src/platform/macos/av_audio.m
@@ -75,7 +75,7 @@
   if ([self.audioCaptureSession canAddInput:audioInput]) {
     [self.audioCaptureSession addInput:audioInput];
   } else {
-    [audioInput dealloc];
+    [audioInput release];
     return -1;
   }
 
@@ -94,6 +94,7 @@
   dispatch_queue_t recordingQueue = dispatch_queue_create("audioSamplingQueue", qos);
 
   [audioOutput setSampleBufferDelegate:self queue:recordingQueue];
+  dispatch_release(recordingQueue);
 
   if ([self.audioCaptureSession canAddOutput:audioOutput]) {
     [self.audioCaptureSession addOutput:audioOutput];
@@ -106,8 +107,6 @@
   self.audioConnection = [audioOutput connectionWithMediaType:AVMediaTypeAudio];
 
   [self.audioCaptureSession startRunning];
-
-  [audioInput release];
   [audioOutput release];
 
   self.samplesArrivedSignal = [[NSCondition alloc] init];


### PR DESCRIPTION
## Summary
- release the audio sampling queue after assigning the delegate to avoid leaking the dispatch queue
- use `release` instead of `dealloc` when rejecting the audio input
- drop the redundant release of the convenience-constructed `audioInput`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9984b177083218e1689723ea8a688