### PR TITLE
Release macOS capture semaphores immediately after wait

### DIFF
--- a/src/platform/macos/display.mm
+++ b/src/platform/macos/display.mm
@@ -70,6 +70,7 @@ namespace platf {
 
       // FIXME: We should time out if an image isn't returned for a while
       dispatch_semaphore_wait(signal, DISPATCH_TIME_FOREVER);
+      dispatch_release(signal);
 
       return capture_e::ok;
     }
@@ -131,6 +132,7 @@ namespace platf {
       }];
 
       dispatch_semaphore_wait(signal, DISPATCH_TIME_FOREVER);
+      dispatch_release(signal);
 
       return 0;
     }


### PR DESCRIPTION
## Summary
- release the semaphore returned by `AVVideo::capture` after waiting in the main capture path
- do the same for the dummy image capture path to avoid leaking dispatch semaphores

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9984be6ec83219762860d85b69103