### PR TITLE
Fix macOS keyboard modifiers for combo keys

### DIFF
--- a/src/platform/macos/input.cpp
+++ b/src/platform/macos/input.cpp
@@ -290,6 +290,7 @@ const KeyCodeMap kKeyCodesMap[] = {
     } else {
       CGEventSetIntegerValueField(event, kCGKeyboardEventKeycode, key);
       CGEventSetType(event, release ? kCGEventKeyUp : kCGEventKeyDown);
+      CGEventSetFlags(event, macos_input->kb_flags);
     }
 
     CGEventPost(kCGHIDEventTap, event);


### PR DESCRIPTION
## Summary
- ensure macOS keyboard events include the active modifier flags when posting non-modifier keys
- fix modifier combinations such as Alt+Tab that previously lost the modifier state

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0b8c8f6dc832183d01ab39186c824